### PR TITLE
fix repograph environment and readme

### DIFF
--- a/dars-agent/README.md
+++ b/dars-agent/README.md
@@ -52,8 +52,10 @@ chmod +x repograph/setup_repograph.sh
 
 **5. Install Docker and Pull the Image:** The agent uses a sandboxed environment to run the code. To install Docker, follow the instructions [here](https://docs.docker.com/get-docker/). Then pull the SWE-Agent Docker image and change the permissions of the Docker socket by running the following commands:
 ```bash
-docker pull sweagent/swe-agent:latest
 sudo chmod 666 /var/run/docker.sock
+docker pull sweagent/swe-agent:latest
+chmod +x ./setup.sh
+./setup.sh
 ```
 
 **6. Run the agent:** To run the agent on SWE-Bench Lite, use the following command:

--- a/dars-agent/requirements.txt
+++ b/dars-agent/requirements.txt
@@ -26,3 +26,4 @@ google-generativeai
 langchain-voyageai
 litellm
 grep_ast
+hydra-core

--- a/dars-agent/sweagent/agent/models.py
+++ b/dars-agent/sweagent/agent/models.py
@@ -335,6 +335,11 @@ class LiteLLMCacheModel(AbstractModelBase):
             "cost_per_input_token": 2.5e-06,
             "cost_per_output_token": 1e-05,
         },
+        "hosted_vllm/Qwen/Qwen2.5-Coder-32B-Instruct": {
+            "max_context": 32_000,
+            "cost_per_input_token": 2.5e-06,
+            "cost_per_output_token": 1e-05,
+        },
     }
 
     SHORTCUTS = {
@@ -344,6 +349,7 @@ class LiteLLMCacheModel(AbstractModelBase):
         "claude-3-5-sonnet-20241022": "claude-3-5-sonnet-20241022",
         "claude-3-5-haiku-20241022": "claude-3-5-haiku-20241022",
         "azure/gpt-4o": "azure/gpt-4o",
+        "qwen-2.5-coder": "hosted_vllm/Qwen/Qwen2.5-Coder-32B-Instruct"
     }
 
     def __init__(self, args: ModelArguments, commands: List[Any]):
@@ -407,6 +413,7 @@ class LiteLLMCacheModel(AbstractModelBase):
                 "messages": messages,
                 "temperature": temperature if temperature is not None else self.args.temperature,
                 "top_p": self.args.top_p,
+                "api_base": keys_config.get("LITELLM_API_BASE", ""),
             }
 
             response = completion(**model_params)

--- a/dars-agent/sweagent/environment/construct_graph.py
+++ b/dars-agent/sweagent/environment/construct_graph.py
@@ -1,3 +1,5 @@
+#!/root/miniconda3/envs/aider/bin/python
+
 import colorsys
 import argparse
 import os

--- a/dars-agent/sweagent/environment/swe_env.py
+++ b/dars-agent/sweagent/environment/swe_env.py
@@ -423,6 +423,7 @@ class SWEEnv(gym.Env):
                                                      timeout_duration=LONG_TIMEOUT)
         # resolve the issue of incompatible version for tree-sitter
         self.communicate_with_handling('pip install tree-sitter==0.20.4', error_msg="Failed to install downgrade tree-sitter.\n")
+        self.communicate_with_handling('chmod +x /root/construct_graph.py', error_msg="Failed to make construct graph file executable.\n")
         self.logger.info('Constructing code graph...')
 
         base_path = "/root/persistent_data" if self.args.persistent_volume else ""
@@ -430,7 +431,7 @@ class SWEEnv(gym.Env):
         self.logger.info(f'Code graph path: {code_graph_path}')
 
         response = self.communicate_with_handling(
-            input=f"python3 /root/construct_graph.py --repo_dir {self._repo_name} --output_dir {code_graph_path}",
+            input=f"/root/construct_graph.py --repo_dir {self._repo_name} --output_dir {code_graph_path}",
             error_msg="Failed to initialize code graph\n",
             timeout_duration=LONG_TIMEOUT,
         )


### PR DESCRIPTION
### 🛠️ Fix: Updated Environment for RepoGraph Construction

**Problem:**  
The construction of the RepoGraph was failing due to a missing `tree_sitter_languages` module. The previous environment was using `tree-sitter==0.20.4`, which does not support this module. Upgrading to `tree-sitter==0.21.3` caused version conflicts, preventing the environment from being created successfully.

**Solution:**  
- Switched to a different Conda environment where `tree_sitter_languages` is available and compatible.
- Updated the `README` with proper instructions for setting up the correct environment.
- Added missing packages like `hydra-core` to ensure all dependencies are explicitly listed.

This change ensures the graph construction script runs reliably with the appropriate environment setup.
